### PR TITLE
CI/CD: switch to Docker Compose

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,7 +74,7 @@ jobs:
           script: |
             set -euo pipefail
             mkdir -p /opt/chat
-            cd /chat
+            cd /opt/chat
             
             # 1) 환경변수 설정
             export DOCKER_IMAGE="${DOCKER_IMAGE}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,8 +54,8 @@ jobs:
           port: ${{ secrets.SERVER_SSH_PORT }}
           key: ${{ secrets.SERVER_SSH_KEY }}
           source: "infra/docker-compose.prod.yml"
-          target: "/opt/chat-ws/"
-          strip_components: 1   # ★ infra/를 벗겨서 /opt/chat-ws/docker-compose.prod.yml 로 배치
+          target: "/opt/chat/"
+          strip_components: 1   # ★ infra/를 벗겨서 /opt/chat/docker-compose.prod.yml 로 배치
           overwrite: true
 
       - name: Deploy over SSH (compose pull + up)
@@ -73,8 +73,8 @@ jobs:
           envs: DOCKER_IMAGE,IMAGE_TAG,REGISTRY_USERNAME,REGISTRY_TOKEN
           script: |
             set -euo pipefail
-            mkdir -p /opt/chat-ws
-            cd /opt/chat-ws
+            mkdir -p /chat
+            cd /chat
             
             # 1) 환경변수 설정
             export DOCKER_IMAGE="${DOCKER_IMAGE}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,8 @@ jobs:
           tags: |
             ${{ secrets.DOCKER_IMAGE }}:latest
             ${{ secrets.DOCKER_IMAGE }}:${{ github.sha }}
+          cache-from: type=gha           # ← 캐시 사용
+          cache-to: type=gha,mode=max    # ← 캐시 저장(최대)
 
   deploy:
     needs: docker-build-and-push
@@ -61,19 +63,28 @@ jobs:
         env:
           DOCKER_IMAGE: ${{ secrets.DOCKER_IMAGE }}
           IMAGE_TAG: ${{ github.sha }}
+          REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
+          REGISTRY_TOKEN: ${{ secrets.REGISTRY_TOKEN }}
         with:
           host: ${{ secrets.SERVER_HOST }}
           username: ${{ secrets.SERVER_USER }}
           port: ${{ secrets.SERVER_SSH_PORT }}
           key: ${{ secrets.SERVER_SSH_KEY }}
-          envs: DOCKER_IMAGE,IMAGE_TAG
+          envs: DOCKER_IMAGE,IMAGE_TAG,REGISTRY_USERNAME,REGISTRY_TOKEN
           script: |
             set -euo pipefail
             mkdir -p /opt/chat-ws
             cd /opt/chat-ws
-            # 환경변수로 치환 사용 (서버의 .env는 건드리지 않음)
+            
+            # 1) 환경변수 설정
             export DOCKER_IMAGE="${DOCKER_IMAGE}"
             export IMAGE_TAG="${IMAGE_TAG}"
+            
+            # 2) 레지스트리 로그인 (기본 docker.io, GHCR이면 ghcr.io 명시)
+            : "${REGISTRY_SERVER:=docker.io}"
+            echo "${REGISTRY_TOKEN}" | docker login "${REGISTRY_SERVER}" -u "${REGISTRY_USERNAME}" --password-stdin
+      
+            # 3) 도커 컴포즈로 서비스 배포 (postgres, redis는 재생성하지 않음)
             docker compose -f docker-compose.prod.yml up -d --no-recreate postgres redis
             docker compose -f docker-compose.prod.yml pull app-chat-ws
             docker compose -f docker-compose.prod.yml up -d --no-deps app-chat-ws

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,6 +53,8 @@ jobs:
           key: ${{ secrets.SERVER_SSH_KEY }}
           source: "infra/docker-compose.prod.yml"
           target: "/opt/chat-ws/"
+          strip_components: 1   # ★ infra/를 벗겨서 /opt/chat-ws/docker-compose.prod.yml 로 배치
+          overwrite: true
 
       - name: Deploy over SSH (compose pull + up)
         uses: appleboy/ssh-action@v1.0.3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Inject WebSocket endpoint
+      - name: Inject WebSocket endpoint to index.html
         run: |
           WS_ENDPOINT="${{ secrets.WS_ENDPOINT }}"
           FILE=./chat-ws/src/main/resources/static/index.html
@@ -42,72 +42,37 @@ jobs:
     needs: docker-build-and-push
     runs-on: ubuntu-latest
     steps:
-      - name: Prepare SSH key
-        shell: bash
-        run: |
-          set -euo pipefail
-          KEY_FILE="${RUNNER_TEMP}/ec2.key"
-          printf '%s' "${{ secrets.SERVER_SSH_KEY }}" > "$KEY_FILE"
-          sed -i 's/\r$//' "$KEY_FILE"
-          chmod 600 "$KEY_FILE"
-          echo "KEY_FILE=$KEY_FILE" >> "$GITHUB_ENV"
+      - uses: actions/checkout@v4
+      # 서버로 배포용 compose 업로드 (prod 전용 오버라이드)
+      - name: Upload compose (prod)
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          port: ${{ secrets.SERVER_SSH_PORT }}
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          source: "infra/docker-compose.prod.yml"
+          target: "/opt/chat-ws/"
 
-      - name: Deploy over native SSH
-        shell: bash
+      - name: Deploy over SSH (compose pull + up)
+        uses: appleboy/ssh-action@v1.0.3
         env:
-          HOST:       ${{ secrets.SERVER_HOST }}
-          USER:       ${{ secrets.SERVER_USER }}
-          PORT:       ${{ secrets.SERVER_SSH_PORT }}
-          IMAGE:      ${{ secrets.DOCKER_IMAGE }}
-          REG_USER:   ${{ secrets.REGISTRY_USERNAME }}
-          REG_TOKEN:  ${{ secrets.REGISTRY_TOKEN }}
-          CONTAINER:  ${{ secrets.CONTAINER_NAME }}
-          APP_PORT:   ${{ secrets.APP_PORT }}
-          REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
-          REDIS_HOST: ${{ secrets.PRIVATE_HOST }}
-        run: |
-          set -euo pipefail
-          : "${PORT:=22}"
-          : "${CONTAINER:=websocket-app}"
-          : "${APP_PORT:=8080}"
-
-          IMAGE_LC="$(printf '%s' "$IMAGE" | tr '[:upper:]' '[:lower:]')"
-
-          ssh -i "$KEY_FILE" -p "$PORT" -o StrictHostKeyChecking=no "$USER@$HOST" \
-            bash -s -- "$IMAGE_LC" "$REG_USER" "$REG_TOKEN" "$CONTAINER" "$APP_PORT" "$REDIS_PASSWORD" "$REDIS_HOST" <<'EOS'
-          set -euo pipefail
-          IMAGE="$1"
-          REG_USER="$2"
-          REG_TOKEN="$3"
-          CONTAINER="$4"
-          APP_PORT="$5"
-          REDIS_PASSWORD="$6"
-          REDIS_HOST="$7"
-
-          docker login -u "$REG_USER" -p "$REG_TOKEN"
-          docker pull "$IMAGE:latest"
-
-          docker stop "$CONTAINER" 2>/dev/null || true
-          docker rm   "$CONTAINER" 2>/dev/null || true
-
-          ENV_OPT=""
-          if [ -f /opt/chat-ws/.env ]; then
-            if [ -r /opt/chat-ws/.env ]; then
-              ENV_OPT="--env-file /opt/chat-ws/.env"
-            else
-              echo "[WARN] /opt/chat-ws/.env exists but unreadable; running without env-file."
-            fi
-          else
-            echo "[WARN] /opt/chat-ws/.env not found; running without env-file."
-          fi
-          
-          docker run -d --name "$CONTAINER" \
-          $ENV_OPT \
-          --restart unless-stopped \
-          -p "$APP_PORT":8080 \
-          -e REDIS_PASSWORD="$REDIS_PASSWORD" \
-          -e SPRING_DATA_REDIS_HOST="$REDIS_HOST" \
-          "$IMAGE:latest"
-              
-          docker ps --filter "name=$CONTAINER"
-          EOS
+          DOCKER_IMAGE: ${{ secrets.DOCKER_IMAGE }}
+          IMAGE_TAG: ${{ github.sha }}
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          port: ${{ secrets.SERVER_SSH_PORT }}
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          script: |
+            set -euo pipefail
+            mkdir -p /opt/chat-ws
+            cd /opt/chat-ws
+            # 환경변수로 치환 사용 (서버의 .env는 건드리지 않음)
+            export DOCKER_IMAGE="${DOCKER_IMAGE}"
+            export IMAGE_TAG="${IMAGE_TAG}"
+            docker compose -f docker-compose.prod.yml up -d --no-recreate postgres redis
+            docker compose -f docker-compose.prod.yml pull app-chat-ws
+            docker compose -f docker-compose.prod.yml up -d --no-deps app-chat-ws
+            docker image prune -f
+            

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,7 +73,7 @@ jobs:
           envs: DOCKER_IMAGE,IMAGE_TAG,REGISTRY_USERNAME,REGISTRY_TOKEN
           script: |
             set -euo pipefail
-            mkdir -p /chat
+            mkdir -p /opt/chat
             cd /chat
             
             # 1) 환경변수 설정

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,6 +64,7 @@ jobs:
           username: ${{ secrets.SERVER_USER }}
           port: ${{ secrets.SERVER_SSH_PORT }}
           key: ${{ secrets.SERVER_SSH_KEY }}
+          envs: DOCKER_IMAGE,IMAGE_TAG
           script: |
             set -euo pipefail
             mkdir -p /opt/chat-ws

--- a/chat-ws/src/main/resources/application-local.properties
+++ b/chat-ws/src/main/resources/application-local.properties
@@ -1,7 +1,7 @@
 spring.application.name=websocket
 # Redis ?? ??
 spring.data.redis.host=localhost
-spring.data.redis.port=16379
+spring.data.redis.port=6379
 spring.data.redis.password=${REDIS_PASSWORD}
 
 # (Optional) Redis ?? timeout (ms)

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -1,0 +1,14 @@
+services:
+  app-chat-ws:
+    # 빌드/이미지 대신 소스 마운트 + dev 실행
+    volumes:
+      - ./chat-ws:/app
+    working_dir: /app
+    command: ./gradlew bootRun
+    environment:
+      SPRING_PROFILES_ACTIVE: local
+      SPRING_DATA_REDIS_HOST: redis
+      SPRING_DATA_REDIS_PORT: "6379"
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/localDB
+      SPRING_DATASOURCE_USERNAME: localUser
+      SPRING_DATASOURCE_PASSWORD: secret

--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -27,7 +27,7 @@ services:
       retries: 20
 
   app-chat-ws:
-    image: ${DOCKER_IMAGE}:${IMAGE_TAG:-latest}   # ← 여기서 이미지를 참조
+    image: ${DOCKER_IMAGE:-tak002/spring-chat-server}:${IMAGE_TAG:-latest}   # ← 여기서 이미지를 참조
     ports: ["8080:8080"]
     environment:
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/localDB

--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -1,0 +1,46 @@
+# infra/docker-compose.prod.yml
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: localDB
+      POSTGRES_USER: localUser
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-secret}
+    ports: ["5432:5432"]
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
+  redis:
+    image: redis:7-alpine
+    ports: ["6379:6379"]
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
+  app-chat-ws:
+    image: ${DOCKER_IMAGE}:${IMAGE_TAG:-latest}   # ← 여기서 이미지를 참조
+    ports: ["8080:8080"]
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/localDB
+      SPRING_DATASOURCE_USERNAME: localUser
+      SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD:-secret}
+      SPRING_DATA_REDIS_HOST: redis
+      SPRING_DATA_REDIS_PORT: "6379"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    restart: unless-stopped
+
+volumes:
+  pgdata:

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,0 +1,50 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: localDB
+      POSTGRES_USER: localUser
+      POSTGRES_PASSWORD: secret
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+        test: [ "CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB || exit 1" ]
+        interval: 5s
+        timeout: 3s
+        retries: 20
+    restart: unless-stopped
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: [ "CMD", "redis-cli", "ping" ]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+    restart: unless-stopped
+
+  app-chat-ws:
+    build:
+      context: ../chat-ws   # Spring 프로젝트 폴더 경로
+      dockerfile: ../chat-ws/Dockerfile
+    ports:
+      - "8080:8080"
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/localDB
+      SPRING_DATASOURCE_USERNAME: localUser
+      SPRING_DATASOURCE_PASSWORD: secret
+      SPRING_DATA_REDIS_HOST: redis
+      SPRING_DATA_REDIS_PORT: "6379"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    restart: unless-stopped
+
+volumes:
+  pgdata:


### PR DESCRIPTION
이 PR은 채팅 WebSocket 애플리케이션의 배포 워크플로우와 인프라 구성에 중요한 개선을 도입합니다. 주요 변경 사항은 서비스 오케스트레이션에 Docker Compose를 사용하도록 GitHub Actions 배포 프로세스를 리팩터링한 것, 개발/프로덕션용 Compose 파일의 추가·업데이트, 그리고 Redis 포트 설정 수정입니다. 이 업데이트로 배포가 간소화되고 유지보수성이 향상되며 환경 설정이 올바르게 보장됩니다.

 **배포 워크플로우 리팩터링 및 자동화**

* `.github/workflows/deploy.yml`의 GitHub Actions 워크플로우가 이제 `appleboy/scp-action`과 `appleboy/ssh-action`을 사용하여 프로덕션 Compose 파일을 안전하게 업로드하고, 수동 SSH 스크립트를 대체해 SSH를 통한 배포 명령을 자동화합니다. 여기에는 Docker 레지스트리 로그인, 이미지 pull, 서비스 관리를 위한 Docker Compose 명령 실행이 포함됩니다.
* 더 빠른 빌드를 위해 Docker 빌드 단계에 `cache-from` 및 `cache-to` 옵션을 추가하여 GitHub Actions 캐시를 활용했습니다.
* 단계 이름을 더 명확하게 개선했습니다(예: “index.html에 WebSocket 엔드포인트 주입”).

 **인프라 as Code: Docker Compose 파일**

* 프로덕션 배포용 `infra/docker-compose.prod.yml`을 추가했습니다. PostgreSQL, Redis, 채팅 WebSocket 앱 서비스를 정의하고, 헬스체크와 환경 변수를 설정했습니다.
* 로컬 개발용 `infra/docker-compose.dev.yml`을 추가했습니다. 앱 소스를 마운트하고 Gradle 개발 모드로 실행합니다.
* 기본 Compose 파일로 `infra/docker-compose.yml`을 추가했습니다. 로컬에서 모든 서비스를 빌드/실행하며, 헬스체크와 환경 설정을 포함합니다.

 **설정 수정**

* `chat-ws/src/main/resources/application-local.properties`의 Redis 포트를 Compose 설정과 일치하도록 비표준 `16379`에서 표준 `6379`로 수정했습니다.
